### PR TITLE
Add AGENTS guidelines and improve MCP docstrings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Repository Guidelines
+
+These instructions apply to all files in this repository.
+
+- Use Google-style docstrings for modules and functions, including **Args** and
+  **Returns** sections where applicable.
+- Keep docstrings concise yet descriptive so tools and clients understand the
+  behavior of each function.
+- After modifying code, run the test suite with `pytest` to verify that the
+  project remains stable.
+

--- a/src/googleplay_mcp/server.py
+++ b/src/googleplay_mcp/server.py
@@ -1,3 +1,9 @@
+"""MCP server exposing Google Play tools.
+
+This module wires together tool implementations and registers them with a
+`FastMCP` instance so that they can be invoked by MCP clients.
+"""
+
 from mcp.server.fastmcp import FastMCP
 
 from .models import (
@@ -22,7 +28,15 @@ mcp = FastMCP(
 
 @mcp.tool()
 def list_reviews(payload: ListReviewsIn) -> ListReviewsOut:
-    """Return recent Play Store reviews for a given package."""
+    """Fetch recent Play Store reviews for a package.
+
+    Args:
+        payload: Parameters including the package name, maximum number of
+            results to return and an optional translation language.
+
+    Returns:
+        ListReviewsOut: Review data returned by the Android Publisher API.
+    """
     data = list_reviews_impl(
         package_name=payload.package_name,
         max_results=payload.max_results,
@@ -33,7 +47,15 @@ def list_reviews(payload: ListReviewsIn) -> ListReviewsOut:
 
 @mcp.tool()
 def reply_to_review(payload: ReplyReviewIn) -> ReplyReviewOut:
-    """Reply to a specific Play Store review by its reviewId."""
+    """Send a reply to a specific Play Store review.
+
+    Args:
+        payload: Includes the package name, the review identifier and the
+            reply text.
+
+    Returns:
+        ReplyReviewOut: API response confirming the reply.
+    """
     data = reply_review_impl(
         package_name=payload.package_name,
         review_id=payload.review_id,
@@ -44,7 +66,15 @@ def reply_to_review(payload: ReplyReviewIn) -> ReplyReviewOut:
 
 @mcp.tool()
 def crash_rate(payload: CrashRateIn) -> CrashRateOut:
-    """Query crash-rate metrics for a package between two dates (DAILY aggregation)."""
+    """Retrieve crash-rate metrics for a package over a date range.
+
+    Args:
+        payload: Contains the package name, start and end dates and an optional
+            timezone for interpreting the date range.
+
+    Returns:
+        CrashRateOut: Crash-rate metrics from the Play Developer Reporting API.
+    """
     data = crash_rate_query_impl(
         package_name=payload.package_name,
         start_date=payload.start_date,
@@ -56,7 +86,16 @@ def crash_rate(payload: CrashRateIn) -> CrashRateOut:
 
 @mcp.tool()
 def get_subscription_v2(payload: SubscriptionGetIn) -> SubscriptionGetOut:
-    """Verify a subscription using purchases.subscriptionsv2.get."""
+    """Verify a user's subscription purchase.
+
+    Args:
+        payload: Includes the application package name and the purchase token
+            returned by the client.
+
+    Returns:
+        SubscriptionGetOut: Result from the
+        `purchases.subscriptionsv2.get` API call.
+    """
     data = subscriptions_v2_get_impl(
         package_name=payload.package_name,
         token=payload.token,

--- a/src/googleplay_mcp/tools/purchases.py
+++ b/src/googleplay_mcp/tools/purchases.py
@@ -6,7 +6,15 @@ from ..auth import service_account_credentials, ANDROID_PUBLISHER_SCOPE
 
 
 def subscriptions_v2_get_impl(package_name: str, token: str) -> Dict[str, Any]:
-    """Check a user's subscription purchase using SubscriptionsV2 (recommended)."""
+    """Check the status of a user's subscription.
+
+    Args:
+        package_name: The application package name.
+        token: Purchase token returned by the client.
+
+    Returns:
+        Dict[str, Any]: Raw response from the Android Publisher API.
+    """
     creds = service_account_credentials(ANDROID_PUBLISHER_SCOPE)
     svc = build("androidpublisher", "v3", credentials=creds, cache_discovery=False)
     # SubscriptionsV2 does not require subscriptionId; the token encodes it.

--- a/src/googleplay_mcp/tools/reporting.py
+++ b/src/googleplay_mcp/tools/reporting.py
@@ -5,9 +5,23 @@ from googleapiclient.discovery import build
 from ..auth import service_account_credentials, REPORTING_SCOPE
 
 
-def crash_rate_query_impl(package_name: str, start_date: str, end_date: str, timezone: str = "Europe/Berlin") -> Dict[
-    str, Any]:
-    """Query crash rate metrics for an app between two dates using Reporting API."""
+def crash_rate_query_impl(
+    package_name: str,
+    start_date: str,
+    end_date: str,
+    timezone: str = "Europe/Berlin",
+) -> Dict[str, Any]:
+    """Query crash-rate metrics for an app.
+
+    Args:
+        package_name: Application package name.
+        start_date: Start date in ``YYYY-MM-DD`` format.
+        end_date: End date in ``YYYY-MM-DD`` format.
+        timezone: IANA timezone identifier for the date range.
+
+    Returns:
+        Dict[str, Any]: Crash-rate metrics grouped by version code.
+    """
     creds = service_account_credentials(REPORTING_SCOPE)
     svc = build("playdeveloperreporting", "v1beta1", credentials=creds, cache_discovery=False)
 
@@ -22,7 +36,7 @@ def crash_rate_query_impl(package_name: str, start_date: str, end_date: str, tim
         "metrics": [
             "crashRate",
             "crashRate7dUserWeighted",
-            "crashRate28dUserWeighted"
+            "crashRate28dUserWeighted",
         ],
         "dimensions": ["versionCode"],
         "pageSize": 1000,

--- a/src/googleplay_mcp/tools/reviews.py
+++ b/src/googleplay_mcp/tools/reviews.py
@@ -5,9 +5,21 @@ from googleapiclient.discovery import build
 from ..auth import service_account_credentials, ANDROID_PUBLISHER_SCOPE
 
 
-def list_reviews_impl(package_name: str, max_results: int = 50, translation_language: str | None = None) -> Dict[
-    str, Any]:
-    """Call Android Publisher API reviews.list."""
+def list_reviews_impl(
+    package_name: str,
+    max_results: int = 50,
+    translation_language: str | None = None,
+) -> Dict[str, Any]:
+    """List recent reviews for an app.
+
+    Args:
+        package_name: Application package name.
+        max_results: Maximum number of reviews to return.
+        translation_language: Optional BCP-47 language code for translations.
+
+    Returns:
+        Dict[str, Any]: Review data from the Android Publisher API.
+    """
     creds = service_account_credentials(ANDROID_PUBLISHER_SCOPE)
     svc = build("androidpublisher", "v3", credentials=creds, cache_discovery=False)
     req = svc.reviews().list(packageName=package_name, maxResults=max_results)
@@ -17,7 +29,16 @@ def list_reviews_impl(package_name: str, max_results: int = 50, translation_lang
 
 
 def reply_review_impl(package_name: str, review_id: str, reply_text: str) -> Dict[str, Any]:
-    """Call Android Publisher API reviews.reply."""
+    """Post a developer reply to a review.
+
+    Args:
+        package_name: Application package name.
+        review_id: Identifier of the review to reply to.
+        reply_text: Text of the developer reply.
+
+    Returns:
+        Dict[str, Any]: API response containing the updated review state.
+    """
     creds = service_account_credentials(ANDROID_PUBLISHER_SCOPE)
     svc = build("androidpublisher", "v3", credentials=creds, cache_discovery=False)
     body = {"replyText": reply_text}


### PR DESCRIPTION
## Summary
- add AGENTS.md with repository guidelines
- expand docstrings for MCP server and Google Play API tools

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b5f2c220ac832aa597943d3200ac5d