### PR TITLE
Add Render deployment script and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1
+FROM python:3.12-slim
+
+# Ensure Python outputs are unbuffered
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# Copy project metadata and source
+COPY pyproject.toml ./
+COPY src ./src
+COPY scripts/render_entrypoint.sh ./render-entrypoint.sh
+
+# Install dependencies
+RUN pip install --no-cache-dir .
+
+# Expose the default MCP HTTP port
+EXPOSE 8000
+
+# Start the MCP server
+ENTRYPOINT ["./render-entrypoint.sh"]
+CMD ["python", "-m", "googleplay_mcp.server"]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ cp .env.example .env  # optional
 ./scripts/run_stdio.sh
 ````
 
+
+## Deploy to Render (EU)
+
+Place your Google service account key at `secrets/service_account.json` before running the deploy script. The script encodes and uploads it as an environment variable for the Render service.
+
+```bash
+export RENDER_API_KEY=your_key BASIC_AUTH_USER=admin BASIC_AUTH_PASSWORD=secret
+./scripts/deploy_render.sh
+```
+
+The script deploys to Render's Frankfurt region, enables HTTP basic authentication, and provisions the service account key at runtime.
+
 ## Tools
 
 ### `list_reviews`

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,15 @@
+services:
+  - type: web
+    name: googleplay-mcp
+    env: docker
+    plan: free
+    region: frankfurt
+    dockerfilePath: Dockerfile
+    autoDeploy: false
+    envVars:
+      - key: RENDER_BASIC_AUTH_USERNAME
+        fromEnv: BASIC_AUTH_USER
+      - key: RENDER_BASIC_AUTH_PASSWORD
+        fromEnv: BASIC_AUTH_PASSWORD
+      - key: SERVICE_ACCOUNT_JSON_B64
+        fromEnv: SERVICE_ACCOUNT_JSON_B64

--- a/scripts/deploy_render.sh
+++ b/scripts/deploy_render.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Deploy the MCP server to Render in the EU region with basic authentication.
+
+set -euo pipefail
+
+if ! command -v render >/dev/null 2>&1; then
+  echo "render CLI not found. Install from https://render.com/docs/cli" >&2
+  exit 1
+fi
+
+: "${RENDER_API_KEY:?Set RENDER_API_KEY to your Render API key}"
+: "${BASIC_AUTH_USER:?Set BASIC_AUTH_USER for HTTP basic auth}"
+: "${BASIC_AUTH_PASSWORD:?Set BASIC_AUTH_PASSWORD for HTTP basic auth}"
+SERVICE_ACCOUNT_JSON_PATH=${SERVICE_ACCOUNT_JSON_PATH:-secrets/service_account.json}
+if [[ ! -f "$SERVICE_ACCOUNT_JSON_PATH" ]]; then
+  echo "Service account JSON not found at $SERVICE_ACCOUNT_JSON_PATH" >&2
+  exit 1
+fi
+
+# Authenticate the CLI
+render login --api-key "$RENDER_API_KEY"
+
+# Export credentials used by render.yaml
+SERVICE_ACCOUNT_JSON_B64=$(base64 "$SERVICE_ACCOUNT_JSON_PATH" | tr -d '\n')
+export BASIC_AUTH_USER BASIC_AUTH_PASSWORD SERVICE_ACCOUNT_JSON_B64
+
+# Deploy blueprint to EU region (Frankfurt)
+render blueprint deploy render.yaml

--- a/scripts/render_entrypoint.sh
+++ b/scripts/render_entrypoint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Decode service account from an environment variable and run the MCP server.
+set -euo pipefail
+
+if [[ -n "${SERVICE_ACCOUNT_JSON_B64:-}" ]]; then
+  mkdir -p /app/secrets
+  printf '%s' "$SERVICE_ACCOUNT_JSON_B64" | base64 -d > /app/secrets/service_account.json
+  export GOOGLE_SERVICE_ACCOUNT_JSON=/app/secrets/service_account.json
+fi
+
+exec "$@"


### PR DESCRIPTION
## Summary
- add Dockerfile for containerizing the MCP server
- provide Render blueprint and deployment script targeting EU region with basic auth
- securely upload service_account.json via base64 and decode in entrypoint
- document Render deployment steps

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b5fcab0a68832aac075db27ec60fec