### PR TITLE
Add ANR metrics and listing experiment tooling

### DIFF
--- a/src/googleplay_mcp/models.py
+++ b/src/googleplay_mcp/models.py
@@ -40,6 +40,31 @@ class CrashRateOut(BaseModel):
     data: Dict[str, Any]
 
 
+class AnrRateIn(BaseModel):
+    """Input for querying ANR rate metrics via Reporting API."""
+    package_name: str
+    start_date: str  # ISO date YYYY-MM-DD
+    end_date: str  # ISO date YYYY-MM-DD
+    timezone: str = "Europe/Berlin"
+
+
+class AnrRateOut(BaseModel):
+    data: Dict[str, Any]
+
+
+# --- Experiments ---
+class ExperimentCreateIn(BaseModel):
+    """Input for creating a store-listing experiment."""
+    package_name: str
+    experiment_id: str
+    variant_id: str
+    traffic_percent: int = Field(50, ge=1, le=99)
+
+
+class ExperimentCreateOut(BaseModel):
+    data: Dict[str, Any]
+
+
 # --- Purchases ---
 class SubscriptionGetIn(BaseModel):
     """Input for checking a subscription purchase using SubscriptionsV2."""

--- a/src/googleplay_mcp/tools/experiments.py
+++ b/src/googleplay_mcp/tools/experiments.py
@@ -1,0 +1,47 @@
+from typing import Any, Dict
+
+from googleapiclient.discovery import build
+
+from ..auth import service_account_credentials, ANDROID_PUBLISHER_SCOPE
+
+
+def create_listing_experiment_impl(
+    package_name: str,
+    experiment_id: str,
+    variant_id: str,
+    traffic_percent: int = 50,
+) -> Dict[str, Any]:
+    """Create a simple store-listing experiment.
+
+    Args:
+        package_name: Application package name.
+        experiment_id: Identifier for the new experiment.
+        variant_id: Identifier for the experiment variant.
+        traffic_percent: Percentage of traffic allocated to the variant.
+
+    Returns:
+        Dict[str, Any]: API response describing the created experiment.
+    """
+    creds = service_account_credentials(ANDROID_PUBLISHER_SCOPE)
+    svc = build("androidpublisher", "v3", credentials=creds, cache_discovery=False)
+
+    edit = svc.edits().insert(packageName=package_name, body={}).execute()
+    edit_id = edit["id"]
+    body = {
+        "experimentId": experiment_id,
+        "trafficPercent": traffic_percent,
+        "type": "STORE_LISTING",
+        "variants": [
+            {
+                "experimentVariantId": variant_id,
+            }
+        ],
+    }
+    resp = (
+        svc.edits()
+        .experiments()
+        .create(packageName=package_name, editId=edit_id, body=body)
+        .execute()
+    )
+    svc.edits().commit(packageName=package_name, editId=edit_id).execute()
+    return resp

--- a/src/googleplay_mcp/tools/reporting.py
+++ b/src/googleplay_mcp/tools/reporting.py
@@ -42,3 +42,42 @@ def crash_rate_query_impl(
         "pageSize": 1000,
     }
     return svc.vitals().crashrate().query(name=name, body=body).execute()
+
+
+def anr_rate_query_impl(
+    package_name: str,
+    start_date: str,
+    end_date: str,
+    timezone: str = "Europe/Berlin",
+) -> Dict[str, Any]:
+    """Query ANR-rate metrics for an app.
+
+    Args:
+        package_name: Application package name.
+        start_date: Start date in ``YYYY-MM-DD`` format.
+        end_date: End date in ``YYYY-MM-DD`` format.
+        timezone: IANA timezone identifier for the date range.
+
+    Returns:
+        Dict[str, Any]: ANR-rate metrics grouped by version code.
+    """
+    creds = service_account_credentials(REPORTING_SCOPE)
+    svc = build("playdeveloperreporting", "v1beta1", credentials=creds, cache_discovery=False)
+
+    name = f"apps/{package_name}/anrRateMetricSet"
+    body = {
+        "timelineSpec": {
+            "startTime": f"{start_date}T00:00:00Z",
+            "endTime": f"{end_date}T23:59:59Z",
+            "aggregationPeriod": "DAILY",
+            "timezone": timezone,
+        },
+        "metrics": [
+            "anrRate",
+            "anrRate7dUserWeighted",
+            "anrRate28dUserWeighted",
+        ],
+        "dimensions": ["versionCode"],
+        "pageSize": 1000,
+    }
+    return svc.vitals().anrrate().query(name=name, body=body).execute()

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -1,0 +1,6 @@
+from googleplay_mcp.models import ExperimentCreateIn
+
+
+def test_experiment_model_defaults():
+    m = ExperimentCreateIn(package_name="com.example.app", experiment_id="exp1", variant_id="v1")
+    assert m.traffic_percent == 50

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,6 +1,11 @@
-from googleplay_mcp.models import CrashRateIn
+from googleplay_mcp.models import CrashRateIn, AnrRateIn
 
 
 def test_reporting_model_defaults():
     m = CrashRateIn(package_name="com.example.app", start_date="2025-01-01", end_date="2025-01-31")
+    assert m.timezone == "Europe/Berlin"
+
+
+def test_anr_model_defaults():
+    m = AnrRateIn(package_name="com.example.app", start_date="2025-01-01", end_date="2025-01-31")
     assert m.timezone == "Europe/Berlin"


### PR DESCRIPTION
## Summary
- query ANR-rate metrics via Play Developer Reporting API
- create store-listing experiments through Android Publisher
- expose new tools and default models with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b74489bc74832aa7a4035fc4048293