### PR TITLE
Add Docker deployment support and CLI runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# syntax=docker/dockerfile:1
+
+# Build stage installs dependencies once so that rebuilds are faster when
+# only application code changes.
+FROM python:3.12-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# Install build dependencies required by google-api-python-client.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY pyproject.toml README.md ./
+COPY src ./src
+
+RUN pip install --no-cache-dir .
+
+# Runtime image
+FROM python:3.12-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    GOOGLE_SERVICE_ACCOUNT_JSON=/secrets/service_account.json \
+    MCP_TRANSPORT=sse \
+    MCP_HOST=0.0.0.0 \
+    MCP_PORT=8000
+
+WORKDIR /app
+
+COPY --from=base /usr/local /usr/local
+COPY --from=base /app/src ./src
+
+EXPOSE 8000
+
+ENTRYPOINT ["python", "-m", "googleplay_mcp"]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ Python **MCP** server exposing Google Play tools:
    - **Android Publisher API**
    - **Play Developer Reporting API**
 2. Create a **Service Account**, download JSON, and grant Play Console access (Users & Permissions → Invite service account).
-3. Set `GOOGLE_SERVICE_ACCOUNT_JSON` env var to the JSON path.
+3. Provide credentials via one of:
+   - `GOOGLE_SERVICE_ACCOUNT_JSON=/path/to/service_account.json`
+   - `GOOGLE_SERVICE_ACCOUNT_JSON_CONTENT='{"type": ...}'`
+   - `GOOGLE_SERVICE_ACCOUNT_JSON_BASE64=$(base64 -w0 service_account.json)`
 
 ## Install & Run (local)
 
@@ -20,8 +23,55 @@ Python **MCP** server exposing Google Play tools:
 conda create -n googleplay-mcp python=3.12 -y
 conda activate googleplay-mcp
 pip install -e .
-cp .env.example .env  # optional
-````
+
+# STDIO (local clients such as Claude Desktop)
+python -m googleplay_mcp --transport stdio
+
+# HTTP/SSE (remote clients / ChatGPT connector)
+python -m googleplay_mcp --transport sse --host 0.0.0.0 --port 8000
+```
+
+### Environment variables
+
+| Variable | Purpose |
+| --- | --- |
+| `GOOGLE_SERVICE_ACCOUNT_JSON` | Path to the service account JSON credentials. |
+| `GOOGLE_SERVICE_ACCOUNT_JSON_CONTENT` | Raw JSON credentials string. Written to `/tmp/googleplay-service-account.json` if no path is provided. |
+| `GOOGLE_SERVICE_ACCOUNT_JSON_BASE64` | Base64-encoded credentials JSON (useful for CI/CD secrets). |
+| `DEFAULT_TZ` | Optional default timezone used by tools that require a timezone. |
+| `MCP_TRANSPORT` | Overrides CLI transport (`stdio`, `sse`, `streamable-http`). |
+| `MCP_HOST` | Host binding for HTTP transports (defaults to `0.0.0.0`). |
+| `MCP_PORT` | Port for HTTP transports (defaults to FastMCP's `8000`). |
+| `MCP_PATH` | Custom endpoint path when using HTTP/SSE. |
+| `MCP_LOG_LEVEL` | Optional log level override passed to FastMCP. |
+| `MCP_CLI_LOG_LEVEL` | Log level used by the CLI bootstrap logging (defaults to `INFO`). |
+| `MCP_STATELESS_HTTP` | Set to `true` to enable stateless HTTP mode. |
+| `MCP_SHOW_BANNER` | Set to `false` to hide the FastMCP startup banner. |
+
+### Docker
+
+Build and run the container locally (ensure the service account file exists):
+
+```bash
+docker build -t googleplay-mcp .
+docker run -p 8000:8000 \
+  -e GOOGLE_SERVICE_ACCOUNT_JSON=/secrets/service_account.json \
+  -v $(pwd)/secrets/service_account.json:/secrets/service_account.json:ro \
+  googleplay-mcp
+```
+
+The default container command exposes the server over SSE on port `8000`. To
+use different transports or ports, override the environment variables at run
+time, for example `-e MCP_TRANSPORT=streamable-http` or `-e MCP_PORT=9000`.
+
+### Docker Compose
+
+```bash
+docker compose up --build
+```
+
+The included `compose.yaml` mounts `./secrets/service_account.json` into the
+container and publishes the server on `http://localhost:8000/sse`.
 
 ## Tools
 
@@ -44,8 +94,8 @@ cp .env.example .env  # optional
 
 ## Using from ChatGPT / MCP Clients
 
-* Local (STDIO): use `mcp.config.example.json` with a client that supports STDIO.
-* Remote (HTTP/SSE): deploy the server behind HTTPS and register as a **custom connector** in ChatGPT (Deep Research). See linked docs.
+* Local (STDIO): use `mcp.config.example.json` with a client that supports STDIO (e.g., Claude Desktop).
+* Remote (HTTP/SSE): expose the container behind HTTPS and register it as a custom connector in ChatGPT Agent Builder or ChatGPT Playground. The SSE endpoint defaults to `https://<your-domain>/sse` and expects POSTs to `https://<your-domain>/messages/`.
 
 ## Notes
 
@@ -58,4 +108,4 @@ cp .env.example .env  # optional
 
 * Add more tools (ANR rate, wake-up, releases, etc.).
 * Wrap long-running calls with retries/timeouts.
-* Add Dockerfile + CI as needed.
+* Add CI.

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,13 @@
+services:
+  googleplay-mcp:
+    build: .
+    image: googleplay-mcp:latest
+    ports:
+      - "8000:8000"
+    environment:
+      GOOGLE_SERVICE_ACCOUNT_JSON: /secrets/service_account.json
+      MCP_TRANSPORT: sse
+      MCP_HOST: 0.0.0.0
+      MCP_PORT: 8000
+    volumes:
+      - ./secrets/service_account.json:/secrets/service_account.json:ro

--- a/mcp.config.example.json
+++ b/mcp.config.example.json
@@ -4,7 +4,9 @@
       "command": "python",
       "args": [
         "-m",
-        "googleplay_mcp.server"
+        "googleplay_mcp",
+        "--transport",
+        "stdio"
       ],
       "env": {
         "GOOGLE_SERVICE_ACCOUNT_JSON": "./secrets/service_account.json",

--- a/mcp.json
+++ b/mcp.json
@@ -4,7 +4,9 @@
       "command": "/home/wahed/miniconda3/envs/googleplay-mcp/bin/python",
       "args": [
         "-m",
-        "googleplay_mcp.server"
+        "googleplay_mcp",
+        "--transport",
+        "stdio"
       ],
       "env": {
         "GOOGLE_SERVICE_ACCOUNT_JSON": "./secrets/service_account.json",

--- a/src/googleplay_mcp/__main__.py
+++ b/src/googleplay_mcp/__main__.py
@@ -1,0 +1,7 @@
+"""Module entry point for ``python -m googleplay_mcp``."""
+
+from .cli import main
+
+
+if __name__ == "__main__":
+    main()

--- a/src/googleplay_mcp/cli.py
+++ b/src/googleplay_mcp/cli.py
@@ -1,0 +1,257 @@
+"""Command-line interface for running the Google Play MCP server."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+from typing import Any, Iterable
+
+from .config import Settings
+from .server import mcp
+
+LOGGER = logging.getLogger(__name__)
+
+SUPPORTED_TRANSPORTS: set[str] = {"stdio", "sse", "streamable-http", "http"}
+HTTP_TRANSPORTS: set[str] = {"sse", "streamable-http", "http"}
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    """Parse command-line arguments and run the MCP server.
+
+    Args:
+        argv: Optional iterable of arguments, primarily useful for tests.
+    """
+
+    logging.basicConfig(level=os.environ.get("MCP_CLI_LOG_LEVEL", "INFO").upper())
+
+    args = build_parser().parse_args(list(argv) if argv is not None else None)
+    Settings.from_env()  # Fail fast if credentials are not configured correctly.
+    run_server(
+        transport=args.transport,
+        host=args.host,
+        port=args.port,
+        path=args.path,
+        log_level=args.log_level,
+        stateless_http=args.stateless_http,
+        show_banner=args.show_banner,
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create the argument parser for the CLI.
+
+    Returns:
+        argparse.ArgumentParser: Configured parser instance.
+    """
+
+    parser = argparse.ArgumentParser(description="Run the Google Play MCP server")
+    parser.add_argument(
+        "--transport",
+        choices=sorted(SUPPORTED_TRANSPORTS),
+        default=None,
+        help="Transport to expose (defaults to MCP_TRANSPORT env var or 'stdio').",
+    )
+    parser.add_argument(
+        "--host",
+        help="Host interface for HTTP/SSE transports (defaults to MCP_HOST or 0.0.0.0).",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        help="Port for HTTP/SSE transports (defaults to MCP_PORT or 8000).",
+    )
+    parser.add_argument(
+        "--path",
+        help=(
+            "Endpoint path for HTTP/SSE transports. Defaults to MCP_PATH or FastMCP's built-in path."
+        ),
+    )
+    parser.add_argument(
+        "--log-level",
+        help="Optional log level override for HTTP transports (e.g., info, debug).",
+    )
+    parser.add_argument(
+        "--stateless-http",
+        action="store_true",
+        default=None,
+        help="Enable stateless HTTP mode (or use MCP_STATELESS_HTTP=true).",
+    )
+    parser.add_argument(
+        "--stateful-http",
+        dest="stateless_http",
+        action="store_false",
+        help="Disable stateless HTTP mode explicitly.",
+    )
+    parser.add_argument(
+        "--show-banner",
+        dest="show_banner",
+        action="store_true",
+        default=None,
+        help="Display the FastMCP startup banner (default: MCP_SHOW_BANNER or true).",
+    )
+    parser.add_argument(
+        "--no-banner",
+        dest="show_banner",
+        action="store_false",
+        help="Suppress the FastMCP startup banner.",
+    )
+    return parser
+
+
+def run_server(
+    *,
+    transport: str | None = None,
+    host: str | None = None,
+    port: int | None = None,
+    path: str | None = None,
+    log_level: str | None = None,
+    stateless_http: bool | None = None,
+    show_banner: bool | None = None,
+) -> None:
+    """Run the FastMCP server using CLI or environment configuration.
+
+    Args:
+        transport: Desired transport (defaults to MCP_TRANSPORT or ``stdio``).
+        host: Host interface when using HTTP transports.
+        port: Port for HTTP transports.
+        path: Endpoint path for HTTP transports.
+        log_level: Optional log level override for HTTP transports.
+        stateless_http: Enables stateless HTTP mode for ``streamable-http``.
+        show_banner: Whether to display FastMCP's startup banner.
+    """
+
+    resolved_transport = _resolve_transport(transport)
+    resolved_host = _resolve_host(host, resolved_transport)
+    resolved_port = _resolve_port(port)
+    resolved_path = path or os.environ.get("MCP_PATH")
+    resolved_log_level = log_level or os.environ.get("MCP_LOG_LEVEL")
+    resolved_stateless = _resolve_bool_env("MCP_STATELESS_HTTP", stateless_http)
+    resolved_banner = _resolve_bool_env("MCP_SHOW_BANNER", show_banner, default=True)
+
+    LOGGER.info(
+        "Starting googleplay-mcp with transport=%s host=%s port=%s path=%s",
+        resolved_transport,
+        resolved_host,
+        resolved_port,
+        resolved_path,
+    )
+
+    run_kwargs: dict[str, Any] = {"show_banner": resolved_banner}
+
+    if resolved_transport in HTTP_TRANSPORTS:
+        if resolved_host is not None:
+            run_kwargs["host"] = resolved_host
+        if resolved_port is not None:
+            run_kwargs["port"] = resolved_port
+        if resolved_path:
+            run_kwargs["path"] = resolved_path
+        if resolved_log_level:
+            run_kwargs["log_level"] = resolved_log_level
+        if resolved_stateless is not None and resolved_transport != "sse":
+            run_kwargs["stateless_http"] = resolved_stateless
+
+    mcp.run(transport=resolved_transport, **run_kwargs)
+
+
+def _resolve_transport(value: str | None) -> str:
+    """Resolve the transport from CLI arguments and environment variables.
+
+    Args:
+        value: Transport from CLI arguments.
+
+    Returns:
+        str: Normalized transport string accepted by FastMCP.
+
+    Raises:
+        ValueError: If the transport value is not recognized.
+    """
+
+    env_value = os.environ.get("MCP_TRANSPORT")
+    candidate = (value or env_value or "stdio").lower()
+
+    if candidate == "http":
+        candidate = "streamable-http"
+
+    if candidate not in SUPPORTED_TRANSPORTS:
+        raise ValueError(
+            f"Unsupported transport '{candidate}'. Choose one of: {sorted(SUPPORTED_TRANSPORTS)}."
+        )
+
+    return candidate
+
+
+def _resolve_host(host: str | None, transport: str) -> str | None:
+    """Determine the host binding for HTTP transports.
+
+    Args:
+        host: Host supplied via CLI arguments.
+        transport: Final transport value.
+
+    Returns:
+        Optional[str]: Host string or ``None`` for STDIO transports.
+    """
+
+    if transport not in HTTP_TRANSPORTS:
+        return None
+
+    env_host = os.environ.get("MCP_HOST")
+    return host or env_host or "0.0.0.0"
+
+
+def _resolve_port(port: int | None) -> int | None:
+    """Determine the port for HTTP transports.
+
+    Args:
+        port: Port supplied via CLI arguments.
+
+    Returns:
+        Optional[int]: Resolved port or ``None`` if not provided.
+    """
+
+    if port is not None:
+        return port
+
+    env_port = os.environ.get("MCP_PORT")
+    if env_port is None:
+        return None
+
+    try:
+        return int(env_port)
+    except ValueError as exc:  # pragma: no cover - defensive, unlikely in tests
+        raise ValueError("MCP_PORT must be an integer.") from exc
+
+
+def _resolve_bool_env(name: str, cli_value: bool | None, *, default: bool | None = None) -> bool | None:
+    """Resolve boolean options from CLI and environment variables.
+
+    Args:
+        name: Environment variable name.
+        cli_value: Value supplied via CLI arguments.
+        default: Default value if neither CLI nor environment specify a value.
+
+    Returns:
+        Optional[bool]: Resolved boolean value or ``None``.
+    """
+
+    if cli_value is not None:
+        return cli_value
+
+    env_value = os.environ.get(name)
+    if env_value is None:
+        return default
+
+    normalized = env_value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+
+    raise ValueError(f"Environment variable {name} must be boolean-like, got: {env_value}")
+
+
+__all__ = [
+    "main",
+    "build_parser",
+    "run_server",
+]

--- a/src/googleplay_mcp/config.py
+++ b/src/googleplay_mcp/config.py
@@ -1,48 +1,127 @@
+"""Environment-driven configuration helpers for the MCP server."""
+
+import base64
+import binascii
 import json
+import logging
 import os
 from pathlib import Path
+from typing import Final
 
 from pydantic import BaseModel
 
 mod_path = Path(__file__).parent
 
+SERVICE_ACCOUNT_ENV: Final[str] = "GOOGLE_SERVICE_ACCOUNT_JSON"
+SERVICE_ACCOUNT_CONTENT_ENV: Final[str] = "GOOGLE_SERVICE_ACCOUNT_JSON_CONTENT"
+SERVICE_ACCOUNT_BASE64_ENV: Final[str] = "GOOGLE_SERVICE_ACCOUNT_JSON_BASE64"
+SERVICE_ACCOUNT_INLINE_DESTINATION: Final[Path] = Path("/tmp/googleplay-service-account.json")
+
+logger = logging.getLogger(__name__)
+
 
 class Settings(BaseModel):
+    """Application settings resolved from the environment."""
+
     service_account_json: str
     default_timezone: str = os.environ.get("DEFAULT_TZ", "Europe/Berlin")
 
     @classmethod
     def from_env(cls) -> "Settings":
-        path = os.environ.get("GOOGLE_SERVICE_ACCOUNT_JSON")
-        # Fallback to conventional local path if env var not set
-        if not path:
-            default_path = mod_path / "../.." / "secrets" / "service_account.json"
-            if os.path.exists(default_path):
-                path = default_path
-            else:
-                raise RuntimeError(
-                    "GOOGLE_SERVICE_ACCOUNT_JSON is not set and ./secrets/service_account.json was not found. "
-                    "Set the env var or place a Service Account JSON at ./secrets/service_account.json."
-                )
+        """Create settings based on environment variables.
 
-        # Normalize to absolute path
-        path = os.path.abspath(path)
-        if not os.path.exists(path):
-            raise RuntimeError(f"Credentials file not found at: {path}")
+        This helper ensures the Google service account credentials are available
+        locally. Inline credentials can be supplied via
+        ``GOOGLE_SERVICE_ACCOUNT_JSON_CONTENT`` or the base64 encoded
+        ``GOOGLE_SERVICE_ACCOUNT_JSON_BASE64`` variables. When inline content is
+        provided it is written to a temporary file and the
+        ``GOOGLE_SERVICE_ACCOUNT_JSON`` variable is updated to reference that
+        path.
 
-        # Validate that it's a Service Account key (not OAuth client credentials)
-        try:
-            with open(path, "r", encoding="utf-8") as f:
-                data = json.load(f)
-        except Exception as e:
-            raise RuntimeError(f"Failed to read credentials JSON at {path}: {e}")
+        Returns:
+            Settings: An initialized settings instance with validated
+            credentials.
 
-        # Service account keys contain type == "service_account" and required fields
-        if data.get("type") != "service_account" or not data.get("private_key") or not data.get("client_email"):
-            raise RuntimeError(
-                "The credentials JSON is not a Service Account key. "
-                "Download a Service Account key (type=service_account) from GCP (IAM > Service Accounts > Keys) "
-                "and set GOOGLE_SERVICE_ACCOUNT_JSON to its path."
-            )
+        Raises:
+            RuntimeError: If the credentials cannot be located or decoded, or if
+            the JSON document is not a valid service account key.
+        """
 
+        path = _resolve_service_account_path()
+        _validate_service_account(path)
         return cls(service_account_json=path)
+
+
+def _resolve_service_account_path() -> str:
+    """Locate the service account credentials file on disk.
+
+    Returns:
+        str: Absolute path to the service account JSON document.
+
+    Raises:
+        RuntimeError: If the credentials cannot be located or inline content
+        cannot be decoded.
+    """
+
+    path = os.environ.get(SERVICE_ACCOUNT_ENV)
+    inline_content = os.environ.get(SERVICE_ACCOUNT_CONTENT_ENV)
+    inline_base64 = os.environ.get(SERVICE_ACCOUNT_BASE64_ENV)
+
+    if inline_base64:
+        try:
+            inline_content = base64.b64decode(inline_base64).decode("utf-8")
+        except (binascii.Error, UnicodeDecodeError) as exc:
+            raise RuntimeError(
+                "Failed to decode GOOGLE_SERVICE_ACCOUNT_JSON_BASE64. Ensure the value "
+                "is base64 encoded UTF-8 JSON."
+            ) from exc
+
+    if inline_content:
+        destination = Path(path) if path else SERVICE_ACCOUNT_INLINE_DESTINATION
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text(inline_content, encoding="utf-8")
+        path = str(destination.resolve())
+        os.environ[SERVICE_ACCOUNT_ENV] = path
+        logger.info("Service account JSON written to %s from inline content.", path)
+
+    if not path:
+        default_path = mod_path / "../.." / "secrets" / "service_account.json"
+        if default_path.exists():
+            path = str(default_path.resolve())
+
+    if not path:
+        raise RuntimeError(
+            "GOOGLE_SERVICE_ACCOUNT_JSON is not set and ./secrets/service_account.json was not found. "
+            "Set the env var, provide GOOGLE_SERVICE_ACCOUNT_JSON_CONTENT, or place a Service Account JSON at ./secrets/service_account.json."
+        )
+
+    path = os.path.abspath(path)
+    if not os.path.exists(path):
+        raise RuntimeError(f"Credentials file not found at: {path}")
+
+    return path
+
+
+def _validate_service_account(path: str) -> None:
+    """Validate that the file at ``path`` is a service account JSON key.
+
+    Args:
+        path: Absolute path to the credentials file.
+
+    Raises:
+        RuntimeError: If the file contents cannot be parsed or if the JSON does
+        not represent a service account key.
+    """
+
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except Exception as exc:
+        raise RuntimeError(f"Failed to read credentials JSON at {path}: {exc}") from exc
+
+    if data.get("type") != "service_account" or not data.get("private_key") or not data.get("client_email"):
+        raise RuntimeError(
+            "The credentials JSON is not a Service Account key. Download a Service Account key "
+            "(type=service_account) from GCP (IAM > Service Accounts > Keys) and provide its contents via "
+            "GOOGLE_SERVICE_ACCOUNT_JSON or GOOGLE_SERVICE_ACCOUNT_JSON_CONTENT."
+        )

--- a/src/googleplay_mcp/server.py
+++ b/src/googleplay_mcp/server.py
@@ -471,5 +471,6 @@ def experiments_trends_report(payload: ExperimentsTrendsReportIn) -> Experiments
 
 
 if __name__ == "__main__":
-    # Default: STDIO transport (works with local MCP clients like Claude Desktop / MCP Inspector)
-    mcp.run(transport="stdio") #transport="streamable-http")
+    from .cli import main
+
+    main()


### PR DESCRIPTION
## Summary
- add a Dockerfile and compose.yaml to simplify deployment and expose the server via SSE by default
- introduce a configurable CLI entrypoint so the server transport, host, and port can be managed via CLI flags or environment variables
- enhance credential loading to accept inline JSON or base64 secrets and update docs/config samples to reference the new entrypoint

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6914e6899d70832a804442a79a59d206)